### PR TITLE
Add missing space in mismatch description

### DIFF
--- a/src/main/java/uk/co/probablyfine/matchers/OptionalMatchers.java
+++ b/src/main/java/uk/co/probablyfine/matchers/OptionalMatchers.java
@@ -63,7 +63,7 @@ public class OptionalMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("Optional with an item that matches" + matcher);
+                description.appendText("Optional with an item that matches " + matcher);
             }
         };
     }

--- a/src/test/java/uk/co/probablyfine/matchers/OptionalMatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/OptionalMatchersTest.java
@@ -75,7 +75,7 @@ public class OptionalMatchersTest {
 
     @Test
     public void containsMatcher_failureMessage() throws Exception {
-        Helper.testFailingMatcher(Optional.of(2), OptionalMatchers.contains(Matchers.equalTo(4)), "Optional with an item that matches<4>","<Optional[2]>");
+        Helper.testFailingMatcher(Optional.of(2), OptionalMatchers.contains(Matchers.equalTo(4)), "Optional with an item that matches <4>","<Optional[2]>");
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/unruly/java-8-matchers/issues/15