### PR TITLE
Fix parameterized return types in StreamMatchers

### DIFF
--- a/src/main/java/uk/co/probablyfine/matchers/StreamMatchers.java
+++ b/src/main/java/uk/co/probablyfine/matchers/StreamMatchers.java
@@ -7,13 +7,17 @@ import org.hamcrest.TypeSafeMatcher;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.PrimitiveIterator;
 import java.util.Objects;
-import java.util.stream.*;
+import java.util.PrimitiveIterator;
+import java.util.stream.BaseStream;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 public class StreamMatchers {
 
-    public static <T,S extends BaseStream<T,S>> Matcher<S> empty() {
+    public static <T,S extends BaseStream<T,? extends S>> Matcher<S> empty() {
         return new TypeSafeMatcher<S>() {
 
             private Iterator<T> actualIterator;
@@ -50,7 +54,7 @@ public class StreamMatchers {
      * @see #startsWithLong
      * @see #startsWithDouble
      */
-    public static <T,S extends BaseStream<T,S>> Matcher<S> equalTo(S expected) {
+    public static <T,S extends BaseStream<T,? extends S>> Matcher<S> equalTo(S expected) {
         return new BaseStreamMatcher<T,S>() {
             @Override
             protected boolean matchesSafely(S actual) {
@@ -912,7 +916,7 @@ public class StreamMatchers {
     private static class IntArrayIterator implements PrimitiveIterator.OfInt {
         private final int[] expected;
         private int currentPos = 0;
-        
+
         public IntArrayIterator(int... expected) {
             this.expected = expected;
         }

--- a/src/main/java/uk/co/probablyfine/matchers/StreamMatchers.java
+++ b/src/main/java/uk/co/probablyfine/matchers/StreamMatchers.java
@@ -370,7 +370,7 @@ public class StreamMatchers {
      * @see #startsWithDouble(double...)
      */
     @SafeVarargs
-    public static <T,S extends BaseStream<T,S>> Matcher<S> contains(Matcher<T>... expectedMatchers) {
+    public static <T, S extends BaseStream<T, ? extends S>> Matcher<S> contains(Matcher<T>... expectedMatchers) {
         return new BaseMatcherStreamMatcher<T,S>() {
 
             @Override
@@ -393,7 +393,7 @@ public class StreamMatchers {
      * @see #startsWithDouble(double...)
      */
     @SafeVarargs
-    public static <T,S extends BaseStream<T,S>> Matcher<S> contains(T... expected) {
+    public static <T, S extends BaseStream<T, ? extends S>> Matcher<S> contains(T... expected) {
         return new BaseStreamMatcher<T,S>() {
             @Override
             protected boolean matchesSafely(S actual) {

--- a/src/main/java/uk/co/probablyfine/matchers/StreamMatchers.java
+++ b/src/main/java/uk/co/probablyfine/matchers/StreamMatchers.java
@@ -13,13 +13,13 @@ import java.util.stream.*;
 
 public class StreamMatchers {
 
-    public static <T,S extends BaseStream<T,S>> Matcher<BaseStream<T,S>> empty() {
-        return new TypeSafeMatcher<BaseStream<T, S>>() {
+    public static <T,S extends BaseStream<T,S>> Matcher<S> empty() {
+        return new TypeSafeMatcher<S>() {
 
             private Iterator<T> actualIterator;
 
             @Override
-            protected boolean matchesSafely(BaseStream<T, S> actual) {
+            protected boolean matchesSafely(S actual) {
                 actualIterator = actual.iterator();
                 return !actualIterator.hasNext();
             }
@@ -30,7 +30,7 @@ public class StreamMatchers {
             }
 
             @Override
-            protected void describeMismatchSafely(BaseStream<T, S> item, Description description) {
+            protected void describeMismatchSafely(S item, Description description) {
                 description.appendText("A non empty Stream starting with ").appendValue(actualIterator.next());
             }
         };
@@ -50,10 +50,10 @@ public class StreamMatchers {
      * @see #startsWithLong
      * @see #startsWithDouble
      */
-    public static <T,S extends BaseStream<T,S>> Matcher<BaseStream<T,S>> equalTo(BaseStream<T, S> expected) {
-        return new BaseStreamMatcher<T,BaseStream<T,S>>() {
+    public static <T,S extends BaseStream<T,S>> Matcher<S> equalTo(S expected) {
+        return new BaseStreamMatcher<T,S>() {
             @Override
-            protected boolean matchesSafely(BaseStream<T,S> actual) {
+            protected boolean matchesSafely(S actual) {
                 return remainingItemsEqual(expected.iterator(), actual.iterator());
             }
         };

--- a/src/test/java/uk/co/probablyfine/matchers/StreamMatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/StreamMatchersTest.java
@@ -230,6 +230,15 @@ public class StreamMatchersTest {
         assertThat("xyz", where(characters, StreamMatchers.equalTo(Stream.of('x', 'y', 'z'))));
     }
 
+    @Test
+    public void contains_handles_types() {
+        assertThat("xyz", where(s -> s.chars().mapToObj(i -> (char) i), contains('x', 'y', 'z')));
+
+        DescribableFunction<String, BaseStream<Character, Stream<Character>>> characters = s -> s.chars().mapToObj(i -> (char) i);
+        assertThat("xyz", where(characters, contains('x', 'y', 'z')));
+        assertThat("xyz", where(characters, not(contains('x', 'y'))));
+    }
+
 
     @Test
     public void contains_failureMessages() throws Exception {

--- a/src/test/java/uk/co/probablyfine/matchers/StreamMatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/StreamMatchersTest.java
@@ -27,7 +27,7 @@ public class StreamMatchersTest {
 
     @Test
     public void contains_failureDifferingSingleItem() throws Exception {
-        assertThat(Stream.of("a"), is(Matchers.not(StreamMatchers.contains("b"))));
+        assertThat(Stream.of("a"), not(StreamMatchers.contains("b")));
     }
 
     @Test
@@ -37,7 +37,7 @@ public class StreamMatchersTest {
 
     @Test
     public void contains_failureDifferingLength() throws Exception {
-        assertThat(Stream.of("a"), is(Matchers.not(StreamMatchers.contains("a", "b"))));
+        assertThat(Stream.of("a"), not(StreamMatchers.contains("a", "b")));
     }
 
     @Test
@@ -47,7 +47,7 @@ public class StreamMatchersTest {
 
     @Test
     public void contains_failureDifferingItems() throws Exception {
-        assertThat(Stream.of("a","c"), is(Matchers.not(StreamMatchers.contains("a", "b"))));
+        assertThat(Stream.of("a","c"), not(StreamMatchers.contains("a", "b")));
     }
 
     @Test
@@ -232,11 +232,11 @@ public class StreamMatchersTest {
 
     @Test
     public void contains_handles_types() {
-        assertThat("xyz", where(s -> s.chars().mapToObj(i -> (char) i), contains('x', 'y', 'z')));
+        assertThat("xyz", where(s -> s.chars().mapToObj(i -> (char) i), StreamMatchers.contains('x', 'y', 'z')));
 
         DescribableFunction<String, BaseStream<Character, Stream<Character>>> characters = s -> s.chars().mapToObj(i -> (char) i);
-        assertThat("xyz", where(characters, contains('x', 'y', 'z')));
-        assertThat("xyz", where(characters, not(contains('x', 'y'))));
+        assertThat("xyz", where(characters, StreamMatchers.contains('x', 'y', 'z')));
+        assertThat("xyz", where(characters, not(StreamMatchers.contains('x', 'y'))));
     }
 
 

--- a/src/test/java/uk/co/probablyfine/matchers/StreamMatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/StreamMatchersTest.java
@@ -4,9 +4,16 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import java.util.stream.*;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 public class StreamMatchersTest {
@@ -203,7 +210,7 @@ public class StreamMatchersTest {
 
     @Test
     public void equalTo_failureMessages() throws Exception {
-        Matcher<BaseStream<String, Stream<String>>> matcher = StreamMatchers.equalTo(Stream.of("a", "b", "c", "d", "e", "f", "g", "h"));
+        Matcher<Stream<String>> matcher = StreamMatchers.equalTo(Stream.of("a", "b", "c", "d", "e", "f", "g", "h"));
         Stream<String> testData = Stream.of("a", "b", "c", "d", "e");
         Helper.testFailingMatcher(testData, matcher, "Stream of [\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\"]", "Stream of [\"a\",\"b\",\"c\",\"d\",\"e\"]");
     }
@@ -219,7 +226,7 @@ public class StreamMatchersTest {
     @Test
     public void equalToIntStream_failureMessages() throws Exception {
         IntStream testData = IntStream.range(8, 10);
-        Matcher<BaseStream<Integer, IntStream>> matcher = StreamMatchers.equalTo(IntStream.range(0, 6));
+        Matcher<IntStream> matcher = StreamMatchers.equalTo(IntStream.range(0, 6));
         Helper.testFailingMatcher(testData, matcher, "Stream of [<0>,<1>,<2>,<3>,<4>,<5>]", "Stream of [<8>,<9>]");
     }
 

--- a/src/test/java/uk/co/probablyfine/matchers/StreamMatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/StreamMatchersTest.java
@@ -3,7 +3,9 @@ package uk.co.probablyfine.matchers;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import uk.co.probablyfine.matchers.function.DescribableFunction;
 
+import java.util.stream.BaseStream;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -15,6 +17,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 
 public class StreamMatchersTest {
     @Test
@@ -213,6 +216,18 @@ public class StreamMatchersTest {
         Matcher<Stream<String>> matcher = StreamMatchers.equalTo(Stream.of("a", "b", "c", "d", "e", "f", "g", "h"));
         Stream<String> testData = Stream.of("a", "b", "c", "d", "e");
         Helper.testFailingMatcher(testData, matcher, "Stream of [\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\"]", "Stream of [\"a\",\"b\",\"c\",\"d\",\"e\"]");
+    }
+
+    @Test
+    public void equalTo_handles_types() {
+        Stream<Character> expectedStream = Stream.of('x', 'y', 'z');
+        assertThat("xyz", where(s -> s.chars().mapToObj(i -> (char) i), StreamMatchers.equalTo(expectedStream)));
+
+        BaseStream<Character, Stream<Character>> expectedBaseStream = Stream.of('x', 'y', 'z');
+        assertThat("xyz", where(s -> s.chars().mapToObj(i -> (char) i), StreamMatchers.equalTo(expectedBaseStream)));
+
+        DescribableFunction<String, BaseStream<Character, Stream<Character>>> characters = s -> s.chars().mapToObj(i -> (char) i);
+        assertThat("xyz", where(characters, StreamMatchers.equalTo(Stream.of('x', 'y', 'z'))));
     }
 
 


### PR DESCRIPTION
Fixes return types for `.equalTo`, `.contains`, and `.empty`.

Duplicates https://github.com/unruly/java-8-matchers/pull/22, which fixes https://github.com/unruly/java-8-matchers/issues/18

This PR also fixes compile issues from Java 9 and later, see c973640