### PR TITLE
Replace methods clashing with Hamcrest API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.7.0-M1</version>
+                <version>5.7.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/uk/co/probablyfine/matchers/OptionalMatchers.java
+++ b/src/main/java/uk/co/probablyfine/matchers/OptionalMatchers.java
@@ -12,7 +12,7 @@ import java.util.OptionalLong;
 public class OptionalMatchers {
 
     /**
-     * Matches an empty Optional.
+     * Matches a not present Optional.
      */
     public static <T> Matcher<Optional<T>> notPresent() {
         return new TypeSafeMatcher<Optional<T>>() {
@@ -29,7 +29,7 @@ public class OptionalMatchers {
     }
 
     /**
-     * Matches an empty Optional.
+     * Matches a not present Optional.
      *
      * @deprecated name clashes with {@link org.hamcrest.Matchers#empty()},
      *             use {@link #notPresent()} instead
@@ -40,7 +40,7 @@ public class OptionalMatchers {
     }
 
     /**
-     * Matches a non empty Optional with the given content
+     * Matches a present Optional with the given content
      *
      * @param content Expected contents of the Optional
      * @param <T> The type of the Optional's content
@@ -60,7 +60,7 @@ public class OptionalMatchers {
     }
 
     /**
-     * Matches a non empty Optional with the given content
+     * Matches a present Optional with the given content
      *
      * @param content Expected contents of the Optional
      * @param <T> The type of the Optional's content
@@ -74,7 +74,7 @@ public class OptionalMatchers {
     }
 
     /**
-     * Matches a non empty Optional with content matching the given matcher
+     * Matches a present Optional with content matching the given matcher
      *
      * @param matcher To match against the Optional's content
      * @param <T> The type of the Optional's content
@@ -95,7 +95,7 @@ public class OptionalMatchers {
     }
 
     /**
-     * Matches a non empty Optional with content matching the given matcher
+     * Matches a present Optional with content matching the given matcher
      *
      * @param matcher To match against the Optional's content
      * @param <T> The type of the Optional's content
@@ -109,9 +109,9 @@ public class OptionalMatchers {
     }
 
     /**
-     * Matches an empty OptionalInt.
+     * Matches an not present OptionalInt.
      */
-    public static Matcher<OptionalInt> emptyInt() {
+    public static Matcher<OptionalInt> notPresentInt() {
         return new TypeSafeMatcher<OptionalInt>() {
             @Override
             protected boolean matchesSafely(OptionalInt item) {
@@ -120,17 +120,28 @@ public class OptionalMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("An empty OptionalInt");
+                description.appendText("An OptionalInt with no value");
             }
         };
     }
 
     /**
-     * Matches a non empty OptionalInt with the given content
+     * Matches a not present OptionalInt.
+     *
+     * @deprecated Matcher is replaced with {@link #notPresentInt()} to
+     *             align with naming of {@link #notPresent()}.
+     */
+    @Deprecated
+    public static Matcher<OptionalInt> emptyInt() {
+        return notPresentInt();
+    }
+
+    /**
+     * Matches a present OptionalInt with the given content
      *
      * @param content Expected contents of the Optional
      */
-    public static Matcher<OptionalInt> containsInt(int content) {
+    public static Matcher<OptionalInt> presentInt(int content) {
         return new TypeSafeMatcher<OptionalInt>() {
             @Override
             protected boolean matchesSafely(OptionalInt item) {
@@ -145,11 +156,24 @@ public class OptionalMatchers {
     }
 
     /**
-     * Matches a non empty OptionalInt with content matching the given matcher
+     * Matches a present OptionalInt with the given content
+     *
+     * @param content Expected contents of the Optional
+     *
+     * @deprecated Matcher is replaced with {@link #presentInt(int)} to
+     *             align with naming of {@link #present(Object)}.
+     */
+    @Deprecated
+    public static Matcher<OptionalInt> containsInt(int content) {
+        return presentInt(content);
+    }
+
+    /**
+     * Matches a present OptionalInt with content matching the given matcher
      *
      * @param matcher To match against the OptionalInt's content
      */
-    public static Matcher<OptionalInt> containsInt(Matcher<Integer> matcher) {
+    public static Matcher<OptionalInt> presentInt(Matcher<Integer> matcher) {
         return new TypeSafeMatcher<OptionalInt>() {
             @Override
             protected boolean matchesSafely(OptionalInt item) {
@@ -158,15 +182,28 @@ public class OptionalMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("OptionalInt with an item that matches" + matcher);
+                description.appendText("OptionalInt with an item that matches " + matcher);
             }
         };
     }
 
     /**
-     * Matches an empty OptionalLong.
+     * Matches a present OptionalInt with content matching the given matcher
+     *
+     * @param matcher To match against the OptionalInt's content
+     *
+     * @deprecated Matcher is replaced with {@link #presentInt(Matcher)} to
+     *             align with naming of {@link #present(Matcher)}.
      */
-    public static Matcher<OptionalLong> emptyLong() {
+    @Deprecated
+    public static Matcher<OptionalInt> containsInt(Matcher<Integer> matcher) {
+        return presentInt(matcher);
+    }
+
+    /**
+     * Matches an OptionalLong with no value.
+     */
+    public static Matcher<OptionalLong> notPresentLong() {
         return new TypeSafeMatcher<OptionalLong>() {
             @Override
             protected boolean matchesSafely(OptionalLong item) {
@@ -175,17 +212,28 @@ public class OptionalMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("An empty OptionalLong");
+                description.appendText("An OptionalLong with no value");
             }
         };
     }
 
     /**
-     * Matches a non empty OptionalLong with the given content
+     * Matches a not present OptionalLong.
+     *
+     * @deprecated Matcher is replaced with {@link #notPresentLong()} to
+     *             align with naming of {@link #notPresent()}.
+     */
+    @Deprecated
+    public static Matcher<OptionalLong> emptyLong() {
+        return notPresentLong();
+    }
+
+    /**
+     * Matches a present OptionalLong with the given content
      *
      * @param content Expected contents of the Optional
      */
-    public static Matcher<OptionalLong> containsLong(long content) {
+    public static Matcher<OptionalLong> presentLong(long content) {
         return new TypeSafeMatcher<OptionalLong>() {
             @Override
             protected boolean matchesSafely(OptionalLong item) {
@@ -200,11 +248,24 @@ public class OptionalMatchers {
     }
 
     /**
-     * Matches a non empty OptionalLong with content matching the given matcher
+     * Matches a present OptionalLong with the given content
+     *
+     * @param content Expected contents of the Optional
+     *
+     * @deprecated Matcher is replaced with {@link #presentLong(long)} to
+     *             align with naming of {@link #present(Object)}.
+     */
+    @Deprecated
+    public static Matcher<OptionalLong> containsLong(long content) {
+        return presentLong(content);
+    }
+
+    /**
+     * Matches a present OptionalLong with content matching the given matcher
      *
      * @param matcher To match against the OptionalLong's content
      */
-    public static Matcher<OptionalLong> containsLong(Matcher<Long> matcher) {
+    public static Matcher<OptionalLong> presentLong(Matcher<Long> matcher) {
         return new TypeSafeMatcher<OptionalLong>() {
             @Override
             protected boolean matchesSafely(OptionalLong item) {
@@ -213,15 +274,28 @@ public class OptionalMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("OptionalLong with an item that matches" + matcher);
+                description.appendText("OptionalLong with an item that matches " + matcher);
             }
         };
     }
 
     /**
-     * Matches an empty OptionalDouble.
+     * Matches a present OptionalLong with content matching the given matcher
+     *
+     * @param matcher To match against the OptionalLong's content
+     *
+     * @deprecated Matcher is replaced with {@link #presentLong(Matcher)} to
+     *             align with naming of {@link #present(Matcher)}.
      */
-    public static Matcher<OptionalDouble> emptyDouble() {
+    @Deprecated
+    public static Matcher<OptionalLong> containsLong(Matcher<Long> matcher) {
+        return presentLong(matcher);
+    }
+
+    /**
+     * Matches a not present OptionalDouble.
+     */
+    public static Matcher<OptionalDouble> notPresentDouble() {
         return new TypeSafeMatcher<OptionalDouble>() {
             @Override
             protected boolean matchesSafely(OptionalDouble item) {
@@ -230,17 +304,28 @@ public class OptionalMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("An empty OptionalDouble");
+                description.appendText("An OptionalDouble with no value");
             }
         };
     }
 
     /**
-     * Matches a non empty OptionalDouble with the given content
+     * Matches a not present OptionalDouble.
+     *
+     * @deprecated Matcher is replaced with {@link #notPresentDouble()} to
+     *             align with naming of {@link #notPresent()}.
+     */
+    @Deprecated
+    public static Matcher<OptionalDouble> emptyDouble() {
+        return notPresentDouble();
+    }
+
+    /**
+     * Matches a present OptionalDouble with the given content
      *
      * @param content Expected contents of the Optional
      */
-    public static Matcher<OptionalDouble> containsDouble(double content) {
+    public static Matcher<OptionalDouble> presentDouble(double content) {
         return new TypeSafeMatcher<OptionalDouble>() {
             @Override
             protected boolean matchesSafely(OptionalDouble item) {
@@ -255,11 +340,24 @@ public class OptionalMatchers {
     }
 
     /**
-     * Matches a non empty OptionalDouble with content matching the given matcher
+     * Matches a present OptionalDouble with the given content
+     *
+     * @param content Expected contents of the Optional
+     *
+     * @deprecated Matcher is replaced with {@link #presentDouble(double)} to
+     *             align with naming of {@link #present(Object)}.
+     */
+    @Deprecated
+    public static Matcher<OptionalDouble> containsDouble(double content) {
+        return presentDouble(content);
+    }
+
+    /**
+     * Matches a present OptionalDouble with content matching the given matcher
      *
      * @param matcher To match against the OptionalDouble's content
      */
-    public static Matcher<OptionalDouble> containsDouble(Matcher<Double> matcher) {
+    public static Matcher<OptionalDouble> presentDouble(Matcher<Double> matcher) {
         return new TypeSafeMatcher<OptionalDouble>() {
             @Override
             protected boolean matchesSafely(OptionalDouble item) {
@@ -268,8 +366,21 @@ public class OptionalMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("OptionalDouble with an item that matches" + matcher);
+                description.appendText("OptionalDouble with an item that matches " + matcher);
             }
         };
+    }
+
+    /**
+     * Matches a present OptionalDouble with content matching the given matcher
+     *
+     * @param matcher To match against the OptionalDouble's content
+     *
+     * @deprecated Matcher is replaced with {@link #presentDouble(Matcher)} to
+     *             align with naming of {@link #present(Matcher)}.
+     */
+    @Deprecated
+    public static Matcher<OptionalDouble> containsDouble(Matcher<Double> matcher) {
+        return presentDouble(matcher);
     }
 }

--- a/src/main/java/uk/co/probablyfine/matchers/OptionalMatchers.java
+++ b/src/main/java/uk/co/probablyfine/matchers/OptionalMatchers.java
@@ -10,10 +10,11 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 public class OptionalMatchers {
+
     /**
      * Matches an empty Optional.
      */
-    public static <T> Matcher<Optional<T>> empty() {
+    public static <T> Matcher<Optional<T>> notPresent() {
         return new TypeSafeMatcher<Optional<T>>() {
             @Override
             protected boolean matchesSafely(Optional<T> item) {
@@ -22,9 +23,20 @@ public class OptionalMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("An empty Optional");
+                description.appendText("An Optional with no value");
             }
         };
+    }
+
+    /**
+     * Matches an empty Optional.
+     *
+     * @deprecated name clashes with {@link org.hamcrest.Matchers#empty()},
+     *             use {@link #notPresent()} instead
+     */
+    @Deprecated
+    public static <T> Matcher<Optional<T>> empty() {
+        return notPresent();
     }
 
     /**
@@ -33,7 +45,7 @@ public class OptionalMatchers {
      * @param content Expected contents of the Optional
      * @param <T> The type of the Optional's content
      */
-    public static <T> Matcher<Optional<T>> contains(T content) {
+    public static <T> Matcher<Optional<T>> present(T content) {
         return new TypeSafeMatcher<Optional<T>>() {
             @Override
             protected boolean matchesSafely(Optional<T> item) {
@@ -48,13 +60,27 @@ public class OptionalMatchers {
     }
 
     /**
+     * Matches a non empty Optional with the given content
+     *
+     * @param content Expected contents of the Optional
+     * @param <T> The type of the Optional's content
+     *
+     * @deprecated name clashes with {@link org.hamcrest.Matchers#contains(Object...)},
+     *             use {@link #present(Object)} instead
+     */
+    @Deprecated
+    public static <T> Matcher<Optional<T>> contains(T content) {
+        return present(content);
+    }
+
+    /**
      * Matches a non empty Optional with content matching the given matcher
      *
      * @param matcher To match against the Optional's content
      * @param <T> The type of the Optional's content
      * @param <S> The type matched by the matcher, a subtype of T
      */
-    public static <T, S extends T> Matcher<Optional<S>> contains(Matcher<T> matcher) {
+    public static <T, S extends T> Matcher<Optional<S>> present(Matcher<T> matcher) {
         return new TypeSafeMatcher<Optional<S>>() {
             @Override
             protected boolean matchesSafely(Optional<S> item) {
@@ -66,6 +92,20 @@ public class OptionalMatchers {
                 description.appendText("Optional with an item that matches " + matcher);
             }
         };
+    }
+
+    /**
+     * Matches a non empty Optional with content matching the given matcher
+     *
+     * @param matcher To match against the Optional's content
+     * @param <T> The type of the Optional's content
+     * @param <S> The type matched by the matcher, a subtype of T
+     * @deprecated name clashes with {@link org.hamcrest.Matchers#contains(Matcher)},
+     *             use {@link #present(Matcher)} instead
+     */
+    @Deprecated
+    public static <T, S extends T> Matcher<Optional<S>> contains(Matcher<T> matcher) {
+        return present(matcher);
     }
 
     /**

--- a/src/main/java/uk/co/probablyfine/matchers/StreamMatchers.java
+++ b/src/main/java/uk/co/probablyfine/matchers/StreamMatchers.java
@@ -17,7 +17,13 @@ import java.util.stream.Stream;
 
 public class StreamMatchers {
 
-    public static <T,S extends BaseStream<T,? extends S>> Matcher<S> empty() {
+    /**
+     * Matcher for a stream which yields no elements.
+     *
+     * @param <T> The type of items
+     * @param <S> The type of the BaseStream
+     */
+    public static <T,S extends BaseStream<T, ? extends S>> Matcher<S> yieldsNothing() {
         return new TypeSafeMatcher<S>() {
 
             private Iterator<T> actualIterator;
@@ -30,14 +36,33 @@ public class StreamMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("An empty Stream");
+                description.appendText("A Stream yielding no elements");
             }
 
             @Override
             protected void describeMismatchSafely(S item, Description description) {
-                description.appendText("A non empty Stream starting with ").appendValue(actualIterator.next());
+                description.appendText("the Stream started with ").appendValue(actualIterator.next());
+                if (actualIterator.hasNext()) {
+                    description.appendText(" and will yield even more elements");
+                } else {
+                    description.appendText(" and is then exhausted");
+                }
             }
         };
+    }
+
+    /**
+     * Matcher for an empty stream.
+     *
+     * @param <T> The type of items
+     * @param <S> The type of the BaseStream
+     *
+     * @deprecated name clashes with {@link org.hamcrest.Matchers#empty()},
+     *             use {@link #yieldsNothing()} instead
+     */
+    @Deprecated
+    public static <T,S extends BaseStream<T, ? extends S>> Matcher<S> empty() {
+        return yieldsNothing();
     }
 
     /**
@@ -54,13 +79,29 @@ public class StreamMatchers {
      * @see #startsWithLong
      * @see #startsWithDouble
      */
-    public static <T,S extends BaseStream<T,? extends S>> Matcher<S> equalTo(S expected) {
+    public static <T,S extends BaseStream<T,? extends S>> Matcher<S> yieldsSameAs(S expected) {
         return new BaseStreamMatcher<T,S>() {
             @Override
             protected boolean matchesSafely(S actual) {
                 return remainingItemsEqual(expected.iterator(), actual.iterator());
             }
         };
+    }
+
+    /**
+     * A matcher for a finite Stream producing the same number of items as the expected Stream,
+     * and producing equal items as expected in the same order.
+     *
+     * @param expected A BaseStream against which to compare
+     * @param <T> The type of items produced by each BaseStream
+     * @param <S> The type of BaseStream
+     *
+     * @deprecated name clashes with {@link org.hamcrest.Matchers#equalTo(Object)},
+     *             use {@link #yieldsSameAs(BaseStream)} instead
+     */
+    @Deprecated
+    public static <T,S extends BaseStream<T,? extends S>> Matcher<S> equalTo(S expected) {
+        return yieldsSameAs(expected);
     }
 
     /**
@@ -370,14 +411,29 @@ public class StreamMatchers {
      * @see #startsWithDouble(double...)
      */
     @SafeVarargs
-    public static <T, S extends BaseStream<T, ? extends S>> Matcher<S> contains(Matcher<T>... expectedMatchers) {
+    public static <T, S extends BaseStream<T, ? extends S>> Matcher<S> yieldsExactly(Matcher<T>... expectedMatchers) {
         return new BaseMatcherStreamMatcher<T,S>() {
-
             @Override
             protected boolean matchesSafely(S actual) {
                 return remainingItemsMatch(new ArrayIterator<>(expectedMatchers), actual.iterator());
             }
         };
+    }
+
+    /**
+     * The BaseStream must produce exactly the given expected items in order, and no more.
+     *
+     * @param expectedMatchers Matchers for the items that should be produced by the BaseStream
+     * @param <T> The type of items
+     * @param <S> The type of the BaseStream
+     *
+     * @deprecated name clashes with {@link org.hamcrest.Matchers#contains(Matcher...)},
+     *             use {@link #yieldsExactly(Matcher...)} instead
+     */
+    @SafeVarargs
+    @Deprecated
+    public static <T, S extends BaseStream<T, ? extends S>> Matcher<S> contains(Matcher<T>... expectedMatchers) {
+        return yieldsExactly(expectedMatchers);
     }
 
     /**
@@ -393,13 +449,29 @@ public class StreamMatchers {
      * @see #startsWithDouble(double...)
      */
     @SafeVarargs
-    public static <T, S extends BaseStream<T, ? extends S>> Matcher<S> contains(T... expected) {
+    public static <T, S extends BaseStream<T, ? extends S>> Matcher<S> yieldsExactly(T... expected) {
         return new BaseStreamMatcher<T,S>() {
             @Override
             protected boolean matchesSafely(S actual) {
                 return remainingItemsEqual(new ArrayIterator<>(expected), actual.iterator());
             }
         };
+    }
+
+    /**
+     * The BaseStream must produce exactly the given expected items in order, and no more.
+     *
+     * @param expected The items that should be produced by the BaseStream
+     * @param <T> The type of items
+     * @param <S> The type of the BaseStream
+     *
+     * @deprecated name clashes with {@link org.hamcrest.Matchers#contains(Object...)},
+     *             use {@link #yieldsExactly(Object...)} instead
+     */
+    @SafeVarargs
+    @Deprecated
+    public static <T, S extends BaseStream<T, ? extends S>> Matcher<S> contains(T... expected) {
+        return yieldsExactly(expected);
     }
 
     /**

--- a/src/test/java/uk/co/probablyfine/matchers/ApiHelper.java
+++ b/src/test/java/uk/co/probablyfine/matchers/ApiHelper.java
@@ -1,9 +1,5 @@
 package uk.co.probablyfine.matchers;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
-
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 
@@ -12,39 +8,18 @@ import static java.lang.reflect.Modifier.isStatic;
 
 final class ApiHelper {
 
-    private static final ApiInspector hamcrestApi = new ApiInspector(org.hamcrest.Matchers.class, ApiHelper::isMatcherMethod);
-
-    static Matcher<Method> existsInHamcrest() {
-        return new TypeSafeDiagnosingMatcher<Method>() {
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("Matcher method with equivalent in Hamcrest Matchers API");
-            }
-
-            @Override
-            protected boolean matchesSafely(Method method, Description mismatchDescription) {
-                if (isMatcherMethod(method) && hamcrestApi.hasEquivalentTo(method)) {
-                    return true;
-                }
-                mismatchDescription.appendText(describe(method) + " does not exist in Hamcrest Matchers API");
-                return false;
-            }
-        };
-    }
-
-    static boolean isMatcherMethod(Method method) {
+    public static boolean isMatcherMethod(Method method) {
         int modifiers = method.getModifiers();
         return isStatic(modifiers) && isPublic(modifiers) && org.hamcrest.Matcher.class.isAssignableFrom(method.getReturnType());
     }
 
-    static boolean isDeprecated(AnnotatedElement element) {
+    public static boolean isDeprecated(AnnotatedElement element) {
         return element.getAnnotation(Deprecated.class) != null;
     }
 
-    private static String describe(Method method) {
+    public static String describe(Method method) {
         return method.getReturnType().getSimpleName() + " " + method.getName() + "(" + (method.getParameterCount() > 0 ? ".." : "") + ")";
     }
-
 
     private ApiHelper() {
     }

--- a/src/test/java/uk/co/probablyfine/matchers/ApiHelper.java
+++ b/src/test/java/uk/co/probablyfine/matchers/ApiHelper.java
@@ -2,9 +2,11 @@ package uk.co.probablyfine.matchers;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.stream.Stream;
 
 import static java.lang.reflect.Modifier.isPublic;
 import static java.lang.reflect.Modifier.isStatic;
+import static java.util.stream.Collectors.joining;
 
 final class ApiHelper {
 
@@ -18,7 +20,8 @@ final class ApiHelper {
     }
 
     public static String describe(Method method) {
-        return method.getReturnType().getSimpleName() + " " + method.getName() + "(" + (method.getParameterCount() > 0 ? ".." : "") + ")";
+        String parameters = Stream.of(method.getParameterTypes()).map(Class::getSimpleName).collect(joining(","));
+        return method.getReturnType().getSimpleName() + " " + method.getName() + "(" + parameters + ")";
     }
 
     private ApiHelper() {

--- a/src/test/java/uk/co/probablyfine/matchers/ApiHelper.java
+++ b/src/test/java/uk/co/probablyfine/matchers/ApiHelper.java
@@ -1,0 +1,58 @@
+package uk.co.probablyfine.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.lang.reflect.Modifier.isPublic;
+import static java.lang.reflect.Modifier.isStatic;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.groupingBy;
+
+final class ApiHelper {
+
+    static final Map<String, List<Method>> HAMCREST_MATCHER_METHODS_BY_NAME = Stream.of(org.hamcrest.Matchers.class.getMethods())
+            .filter(ApiHelper::isMatcherMethod)
+            .collect(groupingBy(Method::getName));
+
+    static boolean isMatcherMethod(Method method) {
+        int modifiers = method.getModifiers();
+        return isStatic(modifiers) && isPublic(modifiers) && org.hamcrest.Matcher.class.isAssignableFrom(method.getReturnType());
+    }
+
+    static Matcher<Method> existsInHamcrest() {
+        return new TypeSafeDiagnosingMatcher<Method>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Matcher method with equivalent in Hamcrest Matchers API");
+            }
+
+            @Override
+            protected boolean matchesSafely(Method method, Description mismatchDescription) {
+                boolean matches = true;
+                if (!isMatcherMethod(method)) {
+                    mismatchDescription.appendText(describe(method) + " is not a Matcher method");
+                    matches = false;
+                }
+                List<Method> existingMethods = HAMCREST_MATCHER_METHODS_BY_NAME.getOrDefault(method.getName(), emptyList());
+                if (existingMethods.isEmpty()) {
+                    mismatchDescription.appendText((!matches ? ", and " : describe(method) + " ") + "does not exist in Hamcrest Matchers API");
+                    matches = false;
+                }
+                return matches;
+            }
+        };
+    }
+
+    private static String describe(Method method) {
+        return method.getReturnType().getSimpleName() + " " + method.getName() + "(" + (method.getParameterCount() > 0 ? ".." : "") + ")";
+    }
+
+    private ApiHelper() {
+    }
+}

--- a/src/test/java/uk/co/probablyfine/matchers/ApiHelper.java
+++ b/src/test/java/uk/co/probablyfine/matchers/ApiHelper.java
@@ -4,6 +4,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,10 @@ final class ApiHelper {
     static boolean isMatcherMethod(Method method) {
         int modifiers = method.getModifiers();
         return isStatic(modifiers) && isPublic(modifiers) && org.hamcrest.Matcher.class.isAssignableFrom(method.getReturnType());
+    }
+
+    static boolean isDeprecated(AnnotatedElement element) {
+        return element.getAnnotation(Deprecated.class) != null;
     }
 
     static Matcher<Method> existsInHamcrest() {

--- a/src/test/java/uk/co/probablyfine/matchers/ApiInspector.java
+++ b/src/test/java/uk/co/probablyfine/matchers/ApiInspector.java
@@ -28,6 +28,20 @@ final class ApiInspector {
                 .anyMatch(hamcrestMethod -> acceptsArgumentsOfTypes(hamcrestMethod, method.getParameterTypes()));
     }
 
+    public Stream<Method> allMethods() {
+        return apiMethodsByName.values().stream().flatMap(List::stream);
+    }
+
+    public Stream<Method> getDeprecated() {
+        return allMethods().filter(ApiHelper::isDeprecated);
+    }
+
+    public Stream<Method> findRelatedOf(Method method) {
+        return allMethods()
+                .filter(apiMethod -> apiMethod.getName().startsWith(method.getName()))
+                .filter(related -> !related.equals(method));
+    }
+
     private static boolean acceptsArgumentsOfTypes(Method method, Class<?> ... argTypes) {
         Class<?>[] parameterTypes = method.getParameterTypes();
         if (parameterTypes.length != argTypes.length) {
@@ -41,5 +55,8 @@ final class ApiInspector {
         }
         return true;
     }
+
+
+
 
 }

--- a/src/test/java/uk/co/probablyfine/matchers/ApiInspector.java
+++ b/src/test/java/uk/co/probablyfine/matchers/ApiInspector.java
@@ -1,0 +1,45 @@
+package uk.co.probablyfine.matchers;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.groupingBy;
+
+final class ApiInspector {
+
+    private final Map<String, List<Method>> apiMethodsByName;
+
+    public ApiInspector(Class<?> apiClass) {
+        this(apiClass, publicMethod -> true);
+    }
+
+    public ApiInspector(Class<?> apiClass, Predicate<? super Method> partOfApi) {
+        this.apiMethodsByName = Stream.of(apiClass.getMethods())
+            .filter(partOfApi)
+            .collect(groupingBy(Method::getName));
+    }
+
+    public boolean hasEquivalentTo(Method method) {
+        return apiMethodsByName.getOrDefault(method.getName(), emptyList()).stream()
+                .anyMatch(hamcrestMethod -> acceptsArgumentsOfTypes(hamcrestMethod, method.getParameterTypes()));
+    }
+
+    private static boolean acceptsArgumentsOfTypes(Method method, Class<?> ... argTypes) {
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        if (parameterTypes.length != argTypes.length) {
+            return false;
+        } else {
+            for (int i = 0; i < argTypes.length; i++) {
+                if (!parameterTypes[i].isAssignableFrom(argTypes[i])) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+}

--- a/src/test/java/uk/co/probablyfine/matchers/ApiInspectorTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/ApiInspectorTest.java
@@ -1,53 +1,106 @@
 package uk.co.probablyfine.matchers;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
+import java.util.Set;
 
+import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static uk.co.probablyfine.matchers.Java8Matchers.whereNot;
 
 class ApiInspectorTest {
 
-    private final ApiInspector javaStringApi = new ApiInspector(String.class);
-    private final Method equalsMethod;
-    private final Method replaceMethod;
-    private final Method replaceMethod2;
-    private final Method incompatibleReplaceMethod;
+    @Nested
+    class IdentifiesEquivalentMethods {
 
-    class MyString {
-        public String replace(CharSequence target, CharSequence replacement) {
-            return "placeholder";
+        private final ApiInspector javaStringApi = new ApiInspector(String.class);
+        private final Method equalsMethod;
+        private final Method replaceMethod;
+        private final Method replaceMethod2;
+        private final Method incompatibleReplaceMethod;
+
+        public IdentifiesEquivalentMethods() throws Exception {
+            equalsMethod = MyString.class.getMethod("equals", Object.class);
+            replaceMethod = MyString.class.getMethod("replace", CharSequence.class, CharSequence.class);
+            replaceMethod2 = MyString.class.getMethod("replace", CharSequence.class, String.class);
+            incompatibleReplaceMethod = MyString.class.getMethod("replace", CharSequence.class, Object.class);
         }
 
-        public String replace(CharSequence target, String replacement) {
-            return "placeholder";
+        class MyString {
+            public String replace(CharSequence target, CharSequence replacement) {
+                return "placeholder";
+            }
+
+            public String replace(CharSequence target, String replacement) {
+                return "placeholder";
+            }
+
+            public String replace(CharSequence target, Object replacement) {
+                return "placeholder";
+            }
         }
 
-        public String replace(CharSequence target, Object replacement) {
-            return "placeholder";
+        @Test
+        void compatibleArguments() {
+            assertThat(equalsMethod, where(javaStringApi::hasEquivalentTo));
+            assertThat(replaceMethod, where(javaStringApi::hasEquivalentTo));
+            assertThat(replaceMethod2, where(javaStringApi::hasEquivalentTo));
         }
+
+        @Test
+        void incompatibleArguments() {
+            assertThat(incompatibleReplaceMethod, whereNot(javaStringApi::hasEquivalentTo));
+        }
+
     }
 
-    public ApiInspectorTest() throws Exception {
-        equalsMethod = MyString.class.getMethod("equals", Object.class);
-        replaceMethod = MyString.class.getMethod("replace", CharSequence.class, CharSequence.class);
-        replaceMethod2 = MyString.class.getMethod("replace", CharSequence.class, String.class);
-        incompatibleReplaceMethod = MyString.class.getMethod("replace", CharSequence.class, Object.class);
+    @Nested
+    class FindUndeprecatedVariantsOfDeprecatedMethodsTest {
+
+        private final ApiInspector api = new ApiInspector(ApiWithDeprecatedMethods.class);
+        private final Method emptyStringMethod;
+        private final Method deprecatedEmptyMethod;
+        private final Method deprecatedEmptyVariantMethod;
+
+        public FindUndeprecatedVariantsOfDeprecatedMethodsTest() throws Exception {
+            emptyStringMethod = ApiWithDeprecatedMethods.class.getMethod("emptyString");
+            deprecatedEmptyMethod = ApiWithDeprecatedMethods.class.getMethod("empty");
+            deprecatedEmptyVariantMethod = ApiWithDeprecatedMethods.class.getMethod("emptyVariant");
+        }
+
+        class ApiWithDeprecatedMethods {
+            public boolean emptyString() {
+                return false;
+            }
+            @Deprecated
+            public boolean empty() {
+                return emptyString();
+            }
+            @Deprecated
+            public boolean emptyVariant() {
+                return emptyString();
+            }
+        }
+
+        @Test
+        void findsDeprecatedMethods() {
+            assertThat(api.getDeprecated().collect(toSet()), containsInAnyOrder(deprecatedEmptyMethod, deprecatedEmptyVariantMethod));
+        }
+
+        @Test
+        void findsVariantsOfMethod() {
+            Set<Method> relatedToDeprecatedEmpty = api.findRelatedOf(deprecatedEmptyMethod).collect(toSet());
+            assertThat(relatedToDeprecatedEmpty, containsInAnyOrder(emptyStringMethod, deprecatedEmptyVariantMethod));
+        }
+
     }
 
-    @Test
-    void identifiesCompatibleArguments() {
-        assertThat(equalsMethod, where(javaStringApi::hasEquivalentTo));
-        assertThat(replaceMethod, where(javaStringApi::hasEquivalentTo));
-        assertThat(replaceMethod2, where(javaStringApi::hasEquivalentTo));
-    }
 
-    @Test
-    void identifiesIncompatibleArguments() {
-        assertThat(incompatibleReplaceMethod, whereNot(javaStringApi::hasEquivalentTo));
-    }
+
 
 
 }

--- a/src/test/java/uk/co/probablyfine/matchers/ApiInspectorTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/ApiInspectorTest.java
@@ -1,0 +1,53 @@
+package uk.co.probablyfine.matchers;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.whereNot;
+
+class ApiInspectorTest {
+
+    private final ApiInspector javaStringApi = new ApiInspector(String.class);
+    private final Method equalsMethod;
+    private final Method replaceMethod;
+    private final Method replaceMethod2;
+    private final Method incompatibleReplaceMethod;
+
+    class MyString {
+        public String replace(CharSequence target, CharSequence replacement) {
+            return "placeholder";
+        }
+
+        public String replace(CharSequence target, String replacement) {
+            return "placeholder";
+        }
+
+        public String replace(CharSequence target, Object replacement) {
+            return "placeholder";
+        }
+    }
+
+    public ApiInspectorTest() throws Exception {
+        equalsMethod = MyString.class.getMethod("equals", Object.class);
+        replaceMethod = MyString.class.getMethod("replace", CharSequence.class, CharSequence.class);
+        replaceMethod2 = MyString.class.getMethod("replace", CharSequence.class, String.class);
+        incompatibleReplaceMethod = MyString.class.getMethod("replace", CharSequence.class, Object.class);
+    }
+
+    @Test
+    void identifiesCompatibleArguments() {
+        assertThat(equalsMethod, where(javaStringApi::hasEquivalentTo));
+        assertThat(replaceMethod, where(javaStringApi::hasEquivalentTo));
+        assertThat(replaceMethod2, where(javaStringApi::hasEquivalentTo));
+    }
+
+    @Test
+    void identifiesIncompatibleArguments() {
+        assertThat(incompatibleReplaceMethod, whereNot(javaStringApi::hasEquivalentTo));
+    }
+
+
+}

--- a/src/test/java/uk/co/probablyfine/matchers/HamcrestApiMatchers.java
+++ b/src/test/java/uk/co/probablyfine/matchers/HamcrestApiMatchers.java
@@ -1,0 +1,31 @@
+package uk.co.probablyfine.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.lang.reflect.Method;
+
+public class HamcrestApiMatchers {
+
+    static Matcher<Method> existsInHamcrest() {
+        return new TypeSafeDiagnosingMatcher<Method>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Matcher method with equivalent in Hamcrest Matchers API");
+            }
+
+            @Override
+            protected boolean matchesSafely(Method method, Description mismatchDescription) {
+                if (ApiHelper.isMatcherMethod(method) && HamcrestApiMatchers.hamcrestApi.hasEquivalentTo(method)) {
+                    return true;
+                }
+                mismatchDescription.appendText(ApiHelper.describe(method) + " does not exist in Hamcrest Matchers API");
+                return false;
+            }
+        };
+    }
+
+    static final ApiInspector hamcrestApi = new ApiInspector(org.hamcrest.Matchers.class, ApiHelper::isMatcherMethod);
+
+}

--- a/src/test/java/uk/co/probablyfine/matchers/Java8MatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/Java8MatchersTest.java
@@ -3,9 +3,15 @@ package uk.co.probablyfine.matchers;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+
+import static java.util.Comparator.comparing;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static uk.co.probablyfine.matchers.ApiHelper.existsInHamcrest;
 
 public class Java8MatchersTest {
 
@@ -52,6 +58,13 @@ public class Java8MatchersTest {
         int age() {
             return 42;
         }
+    }
+
+
+    @Test
+    void noMatchersNameClashWithHamcrestMatchers() {
+        assertAll(Stream.of(Java8Matchers.class.getMethods()).sorted(comparing(Method::getName))
+                .map(method -> () -> assertThat(method, not(existsInHamcrest()))));
     }
 
 }

--- a/src/test/java/uk/co/probablyfine/matchers/Java8MatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/Java8MatchersTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static uk.co.probablyfine.matchers.ApiHelper.existsInHamcrest;
+import static uk.co.probablyfine.matchers.HamcrestApiMatchers.existsInHamcrest;
 
 public class Java8MatchersTest {
 

--- a/src/test/java/uk/co/probablyfine/matchers/OptionalMatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/OptionalMatchersTest.java
@@ -16,8 +16,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static uk.co.probablyfine.matchers.ApiHelper.describe;
 import static uk.co.probablyfine.matchers.ApiHelper.isDeprecated;
 import static uk.co.probablyfine.matchers.HamcrestApiMatchers.existsInHamcrest;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 
 class OptionalMatchersTest {
 
@@ -85,43 +87,43 @@ class OptionalMatchersTest {
     }
 
     @Test
-    void emptyInt_success() {
-        assertThat(OptionalInt.empty(), OptionalMatchers.emptyInt());
+    void notPresentInt_success() {
+        assertThat(OptionalInt.empty(), OptionalMatchers.notPresentInt());
     }
 
     @Test
-    void emptyInt_failure() {
-        assertThat(OptionalInt.of(0), not(OptionalMatchers.emptyInt()));
+    void notPresentInt_failure() {
+        assertThat(OptionalInt.of(0), not(OptionalMatchers.notPresentInt()));
     }
 
     @Test
-    void containsInt_success() {
-        assertThat(OptionalInt.of(0), OptionalMatchers.containsInt(0));
+    void presentInt_success() {
+        assertThat(OptionalInt.of(0), OptionalMatchers.presentInt(0));
     }
 
     @Test
-    void containsInt_failureDiffering() {
-        assertThat(OptionalInt.of(0), not(OptionalMatchers.containsInt(1)));
+    void presentInt_failureDiffering() {
+        assertThat(OptionalInt.of(0), not(OptionalMatchers.presentInt(1)));
     }
 
     @Test
-    void containsInt_failureEmpty() {
-        assertThat(OptionalInt.empty(), not(OptionalMatchers.containsInt(1)));
+    void presentInt_failureEmpty() {
+        assertThat(OptionalInt.empty(), not(OptionalMatchers.presentInt(1)));
     }
 
     @Test
-    void containsIntMatcher_success() {
-        assertThat(OptionalInt.of(0), OptionalMatchers.containsInt(Matchers.equalTo(0)));
+    void presentIntMatcher_success() {
+        assertThat(OptionalInt.of(0), OptionalMatchers.presentInt(Matchers.equalTo(0)));
     }
 
     @Test
-    void containsIntMatcher_failureEmpty() {
-        assertThat(OptionalInt.empty(), not(OptionalMatchers.containsInt(Matchers.equalTo(1))));
+    void presentIntMatcher_failureEmpty() {
+        assertThat(OptionalInt.empty(), not(OptionalMatchers.presentInt(Matchers.equalTo(1))));
     }
 
     @Test
-    void containsIntMatcher_failureDiffering() {
-        assertThat(OptionalInt.of(0), not(OptionalMatchers.containsInt(Matchers.equalTo(1))));
+    void presentIntMatcher_failureDiffering() {
+        assertThat(OptionalInt.of(0), not(OptionalMatchers.presentInt(Matchers.equalTo(1))));
     }
 
     @Test
@@ -130,4 +132,13 @@ class OptionalMatchersTest {
                 .filter(method -> !isDeprecated(method)).sorted(comparing(Method::getName))
                 .map(method -> () -> assertThat(method, not(existsInHamcrest()))));
     }
+
+    @Test
+    void relatedMatchersOfDeprecatedMatchersAreAlsoDeprecated() {
+        ApiInspector streamMatchersApi = new ApiInspector(OptionalMatchers.class, ApiHelper::isMatcherMethod);
+        assertAll(streamMatchersApi.getDeprecated()
+                .flatMap(streamMatchersApi::findRelatedOf).distinct()
+                .map(relatedMethod -> () -> assertThat(describe(relatedMethod) + " should be deprecated", relatedMethod, where(ApiHelper::isDeprecated))));
+    }
+
 }

--- a/src/test/java/uk/co/probablyfine/matchers/OptionalMatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/OptionalMatchersTest.java
@@ -16,8 +16,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static uk.co.probablyfine.matchers.ApiHelper.existsInHamcrest;
 import static uk.co.probablyfine.matchers.ApiHelper.isDeprecated;
+import static uk.co.probablyfine.matchers.HamcrestApiMatchers.existsInHamcrest;
 
 class OptionalMatchersTest {
 

--- a/src/test/java/uk/co/probablyfine/matchers/StreamMatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/StreamMatchersTest.java
@@ -20,8 +20,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static uk.co.probablyfine.matchers.ApiHelper.existsInHamcrest;
+import static uk.co.probablyfine.matchers.ApiHelper.describe;
 import static uk.co.probablyfine.matchers.ApiHelper.isDeprecated;
+import static uk.co.probablyfine.matchers.HamcrestApiMatchers.existsInHamcrest;
 import static uk.co.probablyfine.matchers.Java8Matchers.where;
 
 class StreamMatchersTest {
@@ -366,6 +367,15 @@ class StreamMatchersTest {
                 .filter(method -> !isDeprecated(method)).sorted(comparing(Method::getName))
                 .map(method -> () -> assertThat(method, not(existsInHamcrest()))));
     }
+
+    @Test
+    void relatedMatchersOfDeprecatedMatchersAreAlsoDeprecated() {
+        ApiInspector streamMatchersApi = new ApiInspector(StreamMatchers.class, ApiHelper::isMatcherMethod);
+        assertAll(streamMatchersApi.getDeprecated()
+                .flatMap(streamMatchersApi::findRelatedOf).distinct()
+                .map(relatedMethod -> () -> assertThat(describe(relatedMethod) + " is deprecated", relatedMethod, where(ApiHelper::isDeprecated))));
+    }
+
 
     private static void usesStreamMatcher(Stream<Integer> stream, Matcher<Stream<Integer>> matcher) {
         assertThat(stream, matcher);

--- a/src/test/java/uk/co/probablyfine/matchers/TimeMatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/TimeMatchersTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static uk.co.probablyfine.matchers.ApiHelper.existsInHamcrest;
+import static uk.co.probablyfine.matchers.HamcrestApiMatchers.existsInHamcrest;
 
 class TimeMatchersTest {
 

--- a/src/test/java/uk/co/probablyfine/matchers/TimeMatchersTest.java
+++ b/src/test/java/uk/co/probablyfine/matchers/TimeMatchersTest.java
@@ -2,13 +2,19 @@ package uk.co.probablyfine.matchers;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.stream.Stream;
 
+import static java.util.Comparator.comparing;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static uk.co.probablyfine.matchers.ApiHelper.existsInHamcrest;
 
 class TimeMatchersTest {
 
@@ -112,4 +118,11 @@ class TimeMatchersTest {
     void shouldNotCompileWithNonTimes() {
         assertThat(Integer.valueOf(3), TimeMatchers.after(Integer.valueOf(4)));
     }*/
+
+    @Test
+    void noMatchersNameClashWithHamcrestMatchers() {
+        assertAll(Stream.of(TimeMatchers.class.getMethods()).sorted(comparing(Method::getName))
+                .map(method -> () -> assertThat(method, not(existsInHamcrest()))));
+    }
+
 }


### PR DESCRIPTION
To fix #8 , this pull request deprecates methods which will clash with methods in `org.hamcrest.Matchers` if static importing from both, and adds new methods with other names to replace them.

The API of java-8-matchers affected by this is:
**OptionalMatchers:**
- `empty` is replaced with `notPresent`
- `contains` is replaced with `present`
- variants for primitives are also replaced, to align with the new naming convention

**StreamMatchers:**
- `empty` is replaced with `yieldsNothing`
- `equalTo` is replaced with `yieldsSameAs`
- `contains` is replaced with `yieldsExactly`


To aid with this change, I made a test for each XyzMatchers class to verify it does not have any _non-deprecated_ method with an equivalent in Hamcrest. It is not in any way a "formally complete" check if a name clashes with matchers from Hamcrest, but it served me as a kind of sanity check for verifying that the methods I have already manually identified were indeed candidates for deprecation. And it will stop us from adding other methods in the future which clash with Hamcrest.

To maintain consistency in naming, there are also tests which ensures that no deprecated method still has a "related" method (e.g. `empty()` and `emptyInt()` in OptionalMatchers) which has not also been deprecated.

In #8, I mentioned the `StreamMatchers.startsWith` variants as clashing with Hamcrest, but I withdraw that, as static importing several methods with same name works fine as long as invocations can be determined unambiguously. Which means that `startsWith` from java-8-matchers clashes with Hamcrest only in the case when used with Stream of strings, and you only match on _one_ element.

```java
import static org.hamcrest.Matchers.startsWith;
import static uk.co.probablyfine.matchers.StreamMatchers.startsWith;
...
assertThat("ab", startsWith("a"));                     //Hamcrest
assertThat(Stream.of("a", "b"), startsWith("a", "b")); //StreamMatchers, compiles fine
assertThat(Stream.of(1, 2), startsWith(1));            //StreamMatchers, compiles fine
assertThat(Stream.of("a", "b"), startsWith("a"));      //StreamMatchers, does not compile :(
```
I think this is such a particular case, and easy to work around, that I am leaning towards it is not worth replacing _all_ the `startsWith`-methods in java-8-matchers.