### PR TITLE
Declare the module name via Manifest.MF 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,13 @@
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.2.0</version>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Automatic-Module-Name>uk.co.probablyfine.matchers</Automatic-Module-Name>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>


### PR DESCRIPTION
The `Automatic-Module-Name` entry shall help to successfully resolve the artifact as an automatic module within modular applications. 
It should be noted, that the name is declared such that this is not changed in the future even with explicit module declaration. (`module-info.java`)