### PR TITLE
Create an explicit modular artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>2.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -83,7 +84,7 @@
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.2.0</version>
                     <configuration>
-                        <failOnWarning>false</failOnWarning>
+                        <failOnWarning>true</failOnWarning>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -165,16 +166,6 @@
                     <execution>
                         <goals>
                             <goal>enforce</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>analyze-only</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -79,11 +79,11 @@
                         </rules>
                     </configuration>
                 </plugin>
-                w<plugin>
+                <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.2.0</version>
                     <configuration>
-                        <failOnWarning>true</failOnWarning>
+                        <failOnWarning>false</failOnWarning>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -100,7 +100,8 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <!-- https://issues.apache.org/jira/browse/MJAVADOC-673 -->
+                    <version>3.0.1</version>
                     <configuration>
                         <doclint>all,-missing</doclint>
                         <quiet>true</quiet>
@@ -110,8 +111,10 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.0.0-M5</version>
                     <configuration>
-                        <argLine>--add-opens uk.co.probablyfine.matchers/uk.co.probablyfine.matchers=ALL-UNNAMED
-                            --add-opens uk.co.probablyfine.matchers/uk.co.probablyfine.matchers.function=ALL-UNNAMED</argLine>
+                        <argLine>
+                            --add-opens uk.co.probablyfine.matchers/uk.co.probablyfine.matchers=ALL-UNNAMED
+                            --add-opens uk.co.probablyfine.matchers/uk.co.probablyfine.matchers.function=ALL-UNNAMED
+                        </argLine>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,13 @@
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.2.0</version>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Automatic-Module-Name>uk.co.probablyfine.matchers</Automatic-Module-Name>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,15 +4,14 @@
 
     <groupId>uk.co.probablyfine</groupId>
     <artifactId>java-8-matchers</artifactId>
-    <version>1.10-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
 
     <name>java-8-matchers</name>
     <description>Hamcrest matchers for features introduced in Java 8: Optional, Stream, the Java Time API, and lambdas.</description>
     <url>https://github.com/mrwilson/java-8-matchers</url>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -80,9 +79,9 @@
                         </rules>
                     </configuration>
                 </plugin>
-                <plugin>
+                w<plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.0</version>
                     <configuration>
                         <failOnWarning>true</failOnWarning>
                     </configuration>
@@ -110,17 +109,14 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.0.0-M5</version>
+                    <configuration>
+                        <argLine>--add-opens uk.co.probablyfine.matchers/uk.co.probablyfine.matchers=ALL-UNNAMED
+                            --add-opens uk.co.probablyfine.matchers/uk.co.probablyfine.matchers.function=ALL-UNNAMED</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.2.0</version>
-                    <configuration>
-                        <archive>
-                            <manifestEntries>
-                                <Automatic-Module-Name>uk.co.probablyfine.matchers</Automatic-Module-Name>
-                            </manifestEntries>
-                        </archive>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,16 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,6 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>2.2</version>
-            <!-- https://stackoverflow.com/questions/68013715/-->
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.co.probablyfine</groupId>
     <artifactId>java-8-matchers</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>java-8-matchers</name>
     <description>Hamcrest matchers for features introduced in Java 8: Optional, Stream, the Java Time API, and lambdas.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>2.2</version>
+            <!-- https://stackoverflow.com/questions/68013715/-->
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module uk.co.probablyfine.matchers {
+    requires org.hamcrest;
+
+    exports uk.co.probablyfine.matchers;
+    exports uk.co.probablyfine.matchers.function;
+}

--- a/src/main/java/uk/co/probablyfine/matchers/Java8Matchers.java
+++ b/src/main/java/uk/co/probablyfine/matchers/Java8Matchers.java
@@ -2,6 +2,7 @@ package uk.co.probablyfine.matchers;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import uk.co.probablyfine.matchers.function.DescribableFunction;
 import uk.co.probablyfine.matchers.function.DescribablePredicate;
@@ -106,6 +107,10 @@ public final class Java8Matchers {
         };
     }
 
+    // https://stackoverflow.com/questions/68013715
+    private void customAssert(String reason, boolean assertion) {
+        MatcherAssert.assertThat(reason, assertion);
+    }
 
     private Java8Matchers() {}
 }

--- a/src/main/java/uk/co/probablyfine/matchers/Java8Matchers.java
+++ b/src/main/java/uk/co/probablyfine/matchers/Java8Matchers.java
@@ -107,7 +107,7 @@ public final class Java8Matchers {
         };
     }
 
-    // https://stackoverflow.com/questions/68013715
+    // https://issues.apache.org/jira/browse/MDEP-759
     private void customAssert(String reason, boolean assertion) {
         MatcherAssert.assertThat(reason, assertion);
     }

--- a/src/main/java/uk/co/probablyfine/matchers/OptionalMatchers.java
+++ b/src/main/java/uk/co/probablyfine/matchers/OptionalMatchers.java
@@ -9,6 +9,9 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
+// https://stackoverflow.com/questions/68013715
+import static org.hamcrest.MatcherAssert.assertThat;
+
 public class OptionalMatchers {
 
     /**

--- a/src/main/java/uk/co/probablyfine/matchers/OptionalMatchers.java
+++ b/src/main/java/uk/co/probablyfine/matchers/OptionalMatchers.java
@@ -9,9 +9,6 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
-// https://stackoverflow.com/questions/68013715
-import static org.hamcrest.MatcherAssert.assertThat;
-
 public class OptionalMatchers {
 
     /**


### PR DESCRIPTION
The changes here include or are tested for:
- [x] Explicit module declaration
- [x] Builds artifact using JDK-17
- [x] Tests work with a configuration tweak
- [ ] Continues to failOnWarning for `analyze-only` goal. - [In-Progress](https://stackoverflow.com/questions/68013715/dependency-not-found-with-release-17-while-analyzing)